### PR TITLE
Fix PSR-0 error message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "classmap": [
             "src/migrations"
         ],
-        "psr-0": {
+        "psr-4": {
             "Atbox\\Invi\\": "src/"
         }
     },


### PR DESCRIPTION
When installing v2 through Composer 2:

[code]
Class Atbox\Invi\Facades\Invi located in ./vendor/atbox/invi/src/Facades/invi.php does not comply with psr-0 autoloading standard. Skipping.
Class Atbox\Invi\Invitation located in ./vendor/atbox/invi/src/invitation.php does not comply with psr-0 autoloading standard. Skipping.
Class Atbox\Invi\InviServiceProvider located in ./vendor/atbox/invi/src/InviServiceProvider.php does not comply with psr-0 autoloading standard. Skipping.
Class Atbox\Invi\Invi located in ./vendor/atbox/invi/src/invi.php does not comply with psr-0 autoloading standard. Skipping.
[/code]